### PR TITLE
Fix AI always 10 years old

### DIFF
--- a/src/controllers/ai.ts
+++ b/src/controllers/ai.ts
@@ -83,7 +83,7 @@ const getAIResponse = async (
   const message = raw_response
     .replace("Aco", bot_name)
     .replace("bot_master", bot_master)
-    .replace(9, bot_age)
+    .replace("9", bot_age)
     .replace("Acobot", bot_company)
     .replace("2012", bot_birth_year)
     .replace("acobot.ai", bot_birth_place)


### PR DESCRIPTION
Fix AI always 10 years old (you previously used ```replace(9, bot_age)```, but the reponse return s string not a number, hence why it doesn't replace the bot age)